### PR TITLE
Redis

### DIFF
--- a/utils/storage/go/Makefile
+++ b/utils/storage/go/Makefile
@@ -27,6 +27,9 @@ test:
 	# go versions installed so that calling go from root may fail
 	sudo env "PATH=$(PATH)" "GOROOT=$(GOROOT)" "AWS_ACCESS_KEY=$(AWS_ACCESS_KEY)" "AWS_SECRET_KEY=$(AWS_SECRET_KEY)" go test '-run=^TestS3' $(EXTRAGOARGS)
 
+test-elasticache:
+	sudo env "PATH=$(PATH)" "GOROOT=$(GOROOT)" "AWS_ACCESS_KEY=$(AWS_ACCESS_KEY)" "AWS_SECRET_KEY=$(AWS_SECRET_KEY)" go test '-run=^TestElasticache' $(EXTRAGOARGS)
+
 test-man:
 	echo "Nothing to test manually"
 

--- a/utils/storage/go/storage_test.go
+++ b/utils/storage/go/storage_test.go
@@ -59,7 +59,7 @@ func TestS3File(t *testing.T) {
 }
 
 func TestElasticache(t *testing.T) {
-	InitStorage("ELASTICACHE", "test4.0vgvbw.ng.0001.usw1.cache.amazonaws.com:6379")
+	InitStorage("ELASTICACHE", "test5.0vgvbw.ng.0001.usw1.cache.amazonaws.com:6379")
 	msg := []byte("test message")
 	Put("testkey", msg)
 	ret := Get("testkey")

--- a/utils/storage/python/Makefile
+++ b/utils/storage/python/Makefile
@@ -23,6 +23,9 @@
 test:
 	python3 -m unittest storage_test.MyTest.test_s3
 
+test-elasticache:
+	python3 -m unittest storage_test.MyTest.test_elasticache
+
 test-man:
 	echo "Nothing to test manually"
 

--- a/utils/storage/python/storage.py
+++ b/utils/storage/python/storage.py
@@ -91,7 +91,7 @@ def get(key, doPickle = True):
         if not doPickle:
             return response['Body'].read()
         else:
-            return pickle.loads(response['Body'].read())
+            return pickle.loads(response)
     elif transferType == XDT:
         log.fatal("XDT is not yet supported")
     elif transferType == ELASTICACHE:
@@ -99,6 +99,6 @@ def get(key, doPickle = True):
         if not doPickle:
             return response['Body'].read()
         else:
-            return pickle.loads(response['Body'].read())
+            return pickle.loads(response)
     else:
          log.fatal("unsupported transfer type!")

--- a/utils/storage/python/storage_test.py
+++ b/utils/storage/python/storage_test.py
@@ -33,7 +33,7 @@ class MyTest(unittest.TestCase):
         self.assertEqual(storage.get("aws-test-key"), msg)
 
     def test_elasticache(self):
-        storage.init("ELASTICACHE","redis://test2.0vgvbw.ng.0001.usw1.cache.amazonaws.com:6379")
+        storage.init("ELASTICACHE","redis://test5.0vgvbw.ng.0001.usw1.cache.amazonaws.com:6379")
         self.assertEqual(storage.elasticache_client.ping(), True)
         msg = b"test msg"
         storage.put("elasticache-test-key", msg)


### PR DESCRIPTION
Fixes python elasticache response handling and improves makefiles for easier testing.

As usual the elasticache redis tests only work on EC2 instances!