### PR TITLE
add support for BUCKET_NAME env variable for tuning halving benchmark

### DIFF
--- a/benchmarks/tuning-halving/driver/main.py
+++ b/benchmarks/tuning-halving/driver/main.py
@@ -80,6 +80,8 @@ XDT = "XDT"
 # set aws credentials:
 AWS_ID = os.getenv('AWS_ACCESS_KEY', "")
 AWS_SECRET = os.getenv('AWS_SECRET_KEY', "")
+# set aws bucket name:
+BUCKET_NAME = os.getenv('BUCKET_NAME','vhive-tuning')
 
 def get_self_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -115,7 +117,7 @@ def generate_hyperparam_sets(param_config):
 class GreeterServicer(helloworld_pb2_grpc.GreeterServicer):
     def __init__(self, transferType, XDTconfig=None):
 
-        self.benchName = 'vhive-tuning'
+        self.benchName = BUCKET_NAME
         self.transferType = transferType
         if transferType == S3:
             self.s3_client = boto3.resource(
@@ -215,7 +217,7 @@ class GreeterServicer(helloworld_pb2_grpc.GreeterServicer):
 def serve():
     transferType = os.getenv('TRANSFER_TYPE', S3)
     if transferType == S3:
-        storage.init("S3", 'vhive-tuning')
+        storage.init("S3", BUCKET_NAME)
         log.info("Using inline or s3 transfers")
         max_workers = int(os.getenv("MAX_SERVER_THREADS", 10))
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))

--- a/benchmarks/tuning-halving/knative_yamls/s3/service-driver.yaml
+++ b/benchmarks/tuning-halving/knative_yamls/s3/service-driver.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containerConcurrency: 1
       containers:
-        - image: docker.io/vhiveease/tuning-halving-driver:latest
+        - image: docker.io/jingren1021/tuning-halving-driver:latest
           imagePullPolicy: Always
           args: ["-tAddr", "trainer.default.svc.cluster.local:80"]
           env:

--- a/benchmarks/tuning-halving/knative_yamls/s3/service-trainer.yaml
+++ b/benchmarks/tuning-halving/knative_yamls/s3/service-trainer.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containerConcurrency: 1
       containers:
-        - image: docker.io/vhiveease/tuning-halving-trainer:latest
+        - image: docker.io/jingren1021/tuning-halving-trainer:latest
           imagePullPolicy: Always
           env:
             - name: TRANSFER_TYPE

--- a/benchmarks/tuning-halving/trainer/main.py
+++ b/benchmarks/tuning-halving/trainer/main.py
@@ -76,7 +76,8 @@ XDT = "XDT"
 # set aws credentials:
 AWS_ID = os.getenv('AWS_ACCESS_KEY', "")
 AWS_SECRET = os.getenv('AWS_SECRET_KEY', "")
-
+# set aws bucket name:
+BUCKET_NAME = os.getenv('BUCKET_NAME','vhive-tuning')
 
 def get_self_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -109,7 +110,7 @@ def model_dispatcher(model_name):
 class TrainerServicer(tuning_pb2_grpc.TrainerServicer):
     def __init__(self, transferType, XDTconfig=None):
 
-        self.benchName = 'vhive-tuning'
+        self.benchName = BUCKET_NAME
         self.transferType = transferType
         self.trainer_id = ""
         if transferType == S3:
@@ -169,7 +170,7 @@ class TrainerServicer(tuning_pb2_grpc.TrainerServicer):
 def serve():
     transferType = os.getenv('TRANSFER_TYPE', S3)
     if transferType == S3:
-        storage.init("S3", 'vhive-tuning')
+        storage.init("S3", BUCKET_NAME)
         log.info("Using inline or s3 transfers")
         max_workers = int(os.getenv("MAX_SERVER_THREADS", 10))
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))


### PR DESCRIPTION
Added support for custom AWS S3 bucket name for users to use their own S3 bucket instead of the default 'vhive-tuning' S3 bucket.