### PR TITLE
add support for BUCKET_NAME env variable for tuning halving benchmark

### DIFF
--- a/benchmarks/tuning-halving/README.md
+++ b/benchmarks/tuning-halving/README.md
@@ -57,4 +57,6 @@ Number of instances per function in a stable flow:
 all benchmarks support all transfer types.
 - `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION` - Standard s3 keys, only needed if the s3
 transfer type is used
+- `BUCKET_NAME` - Set custom s3 bucket name, only needed if the s3 transfer type is used,
+default bucket name is set as 'vhive-tuning'
 - `ENABLE_TRACING` - Toggles tracing.

--- a/benchmarks/tuning-halving/docker-compose-s3-tracing.yml
+++ b/benchmarks/tuning-halving/docker-compose-s3-tracing.yml
@@ -36,6 +36,7 @@ services:
             - TRANSFER_TYPE=S3
             - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
             - AWS_SECRET_KEY=${AWS_SECRET_KEY}
+            - BUCKET_NAME=${BUCKET_NAME}
             - AWS_REGION=us-west-1
             - MAX_SERVER_THREADS=10
             - ENABLE_TRACING=true
@@ -52,6 +53,7 @@ services:
             - TRANSFER_TYPE=S3
             - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
             - AWS_SECRET_KEY=${AWS_SECRET_KEY}
+            - BUCKET_NAME=${BUCKET_NAME}
             - AWS_REGION=us-west-1
             - CONCURRENT_TRAINING=false
             - ENABLE_TRACING=true

--- a/benchmarks/tuning-halving/docker-compose-s3.yml
+++ b/benchmarks/tuning-halving/docker-compose-s3.yml
@@ -36,6 +36,7 @@ services:
             - TRANSFER_TYPE=S3
             - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
             - AWS_SECRET_KEY=${AWS_SECRET_KEY}
+            - BUCKET_NAME=${BUCKET_NAME}
             - AWS_REGION=us-west-1
             - MAX_SERVER_THREADS=10
 
@@ -51,6 +52,7 @@ services:
             - TRANSFER_TYPE=S3
             - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
             - AWS_SECRET_KEY=${AWS_SECRET_KEY}
+            - BUCKET_NAME=${BUCKET_NAME}
             - AWS_REGION=us-west-1
             - CONCURRENT_TRAINING=false
         depends_on:

--- a/benchmarks/tuning-halving/driver/main.py
+++ b/benchmarks/tuning-halving/driver/main.py
@@ -81,6 +81,8 @@ storageBackend = None
 # set aws credentials:
 AWS_ID = os.getenv('AWS_ACCESS_KEY', "")
 AWS_SECRET = os.getenv('AWS_SECRET_KEY', "")
+# set aws bucket name:
+BUCKET_NAME = os.getenv('BUCKET_NAME','vhive-tuning')
 
 def get_self_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -116,7 +118,7 @@ def generate_hyperparam_sets(param_config):
 class GreeterServicer(helloworld_pb2_grpc.GreeterServicer):
     def __init__(self, transferType, XDTconfig=None):
 
-        self.benchName = 'vhive-tuning'
+        self.benchName = BUCKET_NAME
         self.transferType = transferType
         if transferType == S3:
             self.s3_client = boto3.resource(
@@ -217,7 +219,7 @@ def serve():
     transferType = os.getenv('TRANSFER_TYPE', S3)
     if transferType == S3:
         global storageBackend
-        storageBackend = Storage('vhive-tuning')
+        storageBackend = Storage(BUCKET_NAME)
         log.info("Using inline or s3 transfers")
         max_workers = int(os.getenv("MAX_SERVER_THREADS", 10))
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))

--- a/benchmarks/tuning-halving/knative_yamls/s3/service-driver.yaml
+++ b/benchmarks/tuning-halving/knative_yamls/s3/service-driver.yaml
@@ -45,6 +45,8 @@ spec:
               value: ${AWS_ACCESS_KEY}
             - name: AWS_SECRET_KEY
               value: ${AWS_SECRET_KEY}
+            - name: BUCKET_NAME
+              value: ${BUCKET_NAME}
             - name: AWS_REGION
               value: "us-west-1"
             - name: MAX_SERVER_THREADS

--- a/benchmarks/tuning-halving/knative_yamls/s3/service-trainer.yaml
+++ b/benchmarks/tuning-halving/knative_yamls/s3/service-trainer.yaml
@@ -39,6 +39,8 @@ spec:
               value: ${AWS_ACCESS_KEY}
             - name: AWS_SECRET_KEY
               value: ${AWS_SECRET_KEY}
+            - name: BUCKET_NAME
+              value: ${BUCKET_NAME}
             - name: AWS_REGION
               value: "us-west-1"
             - name: MAX_SERVER_THREADS

--- a/benchmarks/tuning-halving/proto/tuning.proto
+++ b/benchmarks/tuning-halving/proto/tuning.proto
@@ -23,11 +23,11 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "com.vhive.stacking";
-option java_outer_classname = "stacking";
-option go_package = "tests/stacking-training/proto";
+option java_package = "com.vhive.tuning";
+option java_outer_classname = "tuning";
+option go_package = "tests/tuning-halving/proto";
 
-package stacking;
+package tuning;
 
 service Trainer {
     rpc Train(TrainRequest) returns (TrainReply) {}

--- a/benchmarks/tuning-halving/trainer/main.py
+++ b/benchmarks/tuning-halving/trainer/main.py
@@ -77,7 +77,8 @@ storageBackend = None
 # set aws credentials:
 AWS_ID = os.getenv('AWS_ACCESS_KEY', "")
 AWS_SECRET = os.getenv('AWS_SECRET_KEY', "")
-
+# set aws bucket name:
+BUCKET_NAME = os.getenv('BUCKET_NAME','vhive-tuning')
 
 def get_self_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -110,7 +111,7 @@ def model_dispatcher(model_name):
 class TrainerServicer(tuning_pb2_grpc.TrainerServicer):
     def __init__(self, transferType, XDTconfig=None):
 
-        self.benchName = 'vhive-tuning'
+        self.benchName = BUCKET_NAME
         self.transferType = transferType
         self.trainer_id = ""
         if transferType == S3:
@@ -171,7 +172,7 @@ def serve():
     transferType = os.getenv('TRANSFER_TYPE', S3)
     if transferType == S3:
         global storageBackend
-        storageBackend = Storage('vhive-tuning')
+        storageBackend = Storage(BUCKET_NAME)
         log.info("Using inline or s3 transfers")
         max_workers = int(os.getenv("MAX_SERVER_THREADS", 10))
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))


### PR DESCRIPTION
Created a new pull request after accidentally closing the previous one.
Added env variable to the YAML files and docker-compose.yml files.
Changes are made referencing previous commit  #54 which added BUCKET_NAME env variable to video analytics.
Please review. 

Sorry for all the mess with pull requests.