### PR TITLE
Fibonacci NodeJS Multicloud Support

### DIFF
--- a/.github/workflows/e2e-fibonacci.yml
+++ b/.github/workflows/e2e-fibonacci.yml
@@ -46,6 +46,7 @@ jobs:
             fibonacci-python,
             fibonacci-nodejs,
             fibonacci-python-lambda,
+            fibonacci-nodejs-lambda,
           ]
     steps:
       - name: Check out code into the Go module directory
@@ -234,6 +235,7 @@ jobs:
         service:
           [
             fibonacci-python-lambda,
+            fibonacci-nodejs-lambda,
           ]
     steps:
       - name: Check out code

--- a/benchmarks/fibonacci/Makefile
+++ b/benchmarks/fibonacci/Makefile
@@ -68,6 +68,12 @@ fibonacci-python-lambda-image: docker/Dockerfile.Lambda python/server.py
 	-f docker/Dockerfile.Lambda \
 	$(ROOT) --load
 
+fibonacci-nodejs-lambda-image: docker/Dockerfile.Lambda nodejs/server.js
+	DOCKER_BUILDKIT=1 docker buildx build \
+	--tag $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/fibonacci-nodejs-lambda:latest \
+	--target fibonacciNodeJSLambda \
+	-f docker/Dockerfile.Lambda \
+	$(ROOT) --load
 
 push-%: %-image
 	docker push docker.io/$(DOCKER_HUB_ACCOUNT)/$(subst push-,,$@):latest

--- a/benchmarks/fibonacci/docker/Dockerfile.Lambda
+++ b/benchmarks/fibonacci/docker/Dockerfile.Lambda
@@ -34,3 +34,16 @@ RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Set the CMD to handler
 CMD [ "server.lambda_handler" ]
+
+#---------- NodeJS -----------#
+FROM public.ecr.aws/lambda/nodejs:18 as fibonacciNodeJSLambda
+
+# Copy function code
+COPY ./benchmarks/fibonacci/nodejs/server.js ./
+COPY ./benchmarks/fibonacci/nodejs/package.json ./
+
+# Install NPM dependencies for function
+RUN npm install
+
+# Set the CMD to your handler
+CMD [ "server.lambda_handler" ]


### PR DESCRIPTION
Please resolve PR [#364](https://github.com/vhive-serverless/vSwarm/pull/364) before this one, since this PR builds on top of the changes introduced in that PR. This PR shall be kept as a draft PR till then.

Multi-Cloud Support for the NodeJS part of the Fibonacci benchmark.
This PR extends multi-cloud support to Fibonacci-NodeJS by adopting the same conventions from PR [#353](https://github.com/vhive-serverless/vSwarm/pull/353).