### PR TITLE
Auth Go Multicloud Support

### DIFF
--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -47,6 +47,7 @@ jobs:
             auth-nodejs,
             auth-python-lambda,
             auth-nodejs-lambda,
+            auth-go-lambda
           ]
 
     steps:
@@ -236,7 +237,8 @@ jobs:
         service:
           [
             auth-python-lambda,
-            auth-nodejs-lambda
+            auth-nodejs-lambda,
+            auth-go-lambda
           ]
     steps:
       - name: Check out code

--- a/benchmarks/auth/Makefile
+++ b/benchmarks/auth/Makefile
@@ -50,6 +50,12 @@ auth-python-lambda-image: docker/Dockerfile.Lambda python/server.py
 	-f docker/Dockerfile.Lambda \
 	$(ROOT) --load
 
+auth-python-lambda-image: docker/Dockerfile.Lambda python/server.py
+	DOCKER_BUILDKIT=1 docker buildx build \
+	--tag $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/auth-python-lambda:latest \
+	--target authPythonLambda \
+	-f docker/Dockerfile.Lambda \
+	$(ROOT) --load
 
 auth-nodejs-lambda-image: docker/Dockerfile.Lambda nodejs/server.js
 	DOCKER_BUILDKIT=1 docker buildx build \

--- a/benchmarks/auth/Makefile
+++ b/benchmarks/auth/Makefile
@@ -65,6 +65,14 @@ auth-nodejs-lambda-image: docker/Dockerfile.Lambda nodejs/server.js
 	$(ROOT) --load
 
 
+auth-go-lambda-image: docker/Dockerfile.Lambda go/server.go
+	DOCKER_BUILDKIT=1 docker buildx build \
+	--tag $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/auth-go-lambda:latest \
+	--target authGoLambda \
+	-f docker/Dockerfile.Lambda \
+	$(ROOT) --load
+
+
 push-%: %-image
 	docker push docker.io/$(DOCKER_HUB_ACCOUNT)/$(subst push-,,$@):latest
 

--- a/benchmarks/auth/docker/Dockerfile.Lambda
+++ b/benchmarks/auth/docker/Dockerfile.Lambda
@@ -47,3 +47,25 @@ RUN npm install
 
 # Set the CMD to your handler
 CMD [ "server.lambda_handler" ]
+
+#---------- GoLang -----------#
+## First stage (Builder):
+FROM vhiveease/golang-builder:latest AS authGoLambdaBuilder
+WORKDIR /app/app/
+RUN apt-get install git ca-certificates
+
+COPY ./utils/tracing/go ../../utils/tracing/go
+COPY ./benchmarks/auth/go/go.mod ./
+COPY ./benchmarks/auth/go/go.sum ./
+COPY ./benchmarks/auth/go/server.go ./
+
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o ./server server.go
+
+# Second stage (Runner):
+FROM scratch as authGoLambda
+WORKDIR /app/
+COPY --from=authGoLambdaBuilder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=authGoLambdaBuilder /app/app/server .
+
+ENTRYPOINT [ "/app/server" ]


### PR DESCRIPTION
Multi-Cloud Support for the Golang part of the Auth benchmark.
This PR extends multi-cloud support to Auth-Go by adopting the same conventions from PR [#353](https://github.com/vhive-serverless/vSwarm/pull/353).