### PR TITLE
Minor Bug Fix in Map-Reduce Workflow

### DIFF
--- a/.github/workflows/e2e-map-reduce.yml
+++ b/.github/workflows/e2e-map-reduce.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Deploy and Test functions from ECR container
         working-directory: runner/aws_lambda_scripts
         run: |
-          python aws_actions.py deploy_lambdafn_from_ecr -n mapreduce-driver-lambda -f mapreduce-driver -p invoke_function -e '{"NUM_MAPPERS":"8","NUM_REDUCERS":"2","IS_LAMBDA":"true"}'
+          python aws_actions.py deploy_lambdafn_from_ecr -n mapreduce-driver-lambda -f mapreduce-driver -p invoke_function -e '{"NUM_MAPPERS":"8","NUM_REDUCERS":"2","IS_LAMBDA":"true","MAPPER_FUNCTION":"mapreduce-mapper","REDUCER_FUNCTION":"mapreduce-reducer"}'
           python aws_actions.py deploy_lambdafn_from_ecr -n mapreduce-mapper-lambda -f mapreduce-mapper -p access_s3
           python aws_actions.py deploy_lambdafn_from_ecr -n mapreduce-reducer-lambda -f mapreduce-reducer -p access_s3
           python aws_actions.py invoke_lambdafn -f mapreduce-driver


### PR DESCRIPTION
Minor Bug Fix in workflow manifest.
While deploying, we need to configure the correct names of the Mapper and Reducer functions as environment variables. Else it will read the default values, which may not be correct. This bug was an oversight on my part, and this PR fixes it.