### PR TITLE
Ignore Opensoure.org from Link Check

### DIFF
--- a/.github/configs/linkcheck.json
+++ b/.github/configs/linkcheck.json
@@ -5,6 +5,9 @@
 		},
         {
             "pattern": "^http://127.0.0.1:*"
+        },
+        {
+            "pattern": "^https://opensource.org*"
         }
     ],
     "replacementPatterns": [


### PR DESCRIPTION
Closes #375 

This looks to be an issue with markdown-link-check and sites that use DoS & Spam protection. Currently, there are two open issues in markdown-link-check in regards to this where sites like Amazon, GoDaddy, Cloudfare, etc. are all reachable but return a 500 error when checked.
[Markdown-link-check issue #109](https://github.com/tcort/markdown-link-check/issues/109)
[Markdown-link-check issue #23](https://github.com/tcort/markdown-link-check/issues/23)

Added Opensource.org to be ignored, it's not a great solution but it helps to stop false negatives. I hope this helps with some of the legwork! 