### PR TITLE
Modified benchmark Makefiles to ensure consistency for make all-image

### DIFF
--- a/benchmarks/aes/Makefile
+++ b/benchmarks/aes/Makefile
@@ -35,11 +35,11 @@ export AWS_ACCESS_KEY := ${AWS_ACCESS_KEY}
 export AWS_SECRET_KEY := ${AWS_SECRET_KEY}
 export AWS_ACCOUNT_ID := ${AWS_ACCOUNT_ID}
 
-all: all_image all_lambda_image
+all: all-image all-lambda-image
 
-all_image: $(ALL_IMAGES)
+all-image: $(ALL_IMAGES)
 
-all_lambda_image: $(ALL_LAMBDA_IMAGES)
+all-lambda-image: $(ALL_LAMBDA_IMAGES)
 
 aes-python-image: docker/Dockerfile python/server.py
 	DOCKER_BUILDKIT=1 docker buildx build \

--- a/benchmarks/auth/Makefile
+++ b/benchmarks/auth/Makefile
@@ -13,11 +13,11 @@ clean: clean-proto
 
 ROOT = ../../
 
-all: all_image all_lambda_image
+all: all-image all-lambda-image
 
-all_image: $(ALL_IMAGES)
+all-image: $(ALL_IMAGES)
 
-all_lambda_image: $(ALL_LAMBDA_IMAGES)
+all-lambda-image: $(ALL_LAMBDA_IMAGES)
 
 auth-python-image: docker/Dockerfile python/server.py
 	DOCKER_BUILDKIT=1 docker buildx build \

--- a/benchmarks/bert/Makefile
+++ b/benchmarks/bert/Makefile
@@ -29,9 +29,9 @@ else
 	DOCKER_RUN_CMD := docker run --gpus=all
 endif
 
-all: all_image
+all: all-image
 
-all_image: $(ALL_IMAGES)
+all-image: $(ALL_IMAGES)
 
 .PHONY: setup
 setup:

--- a/benchmarks/chained-function-eventing/Makefile
+++ b/benchmarks/chained-function-eventing/Makefile
@@ -26,7 +26,7 @@ all: bin/consumer bin/producer
 
 all-image-push: push-all
 
-image-all: image-consumer image-producer
+all-image: image-consumer image-producer
 
 push-all: push-consumer push-producer
 

--- a/benchmarks/fibonacci/Makefile
+++ b/benchmarks/fibonacci/Makefile
@@ -28,9 +28,9 @@ clean: clean-proto
 
 ROOT = ../../
 
-all: all_image
+all: all-image
 
-all_image: $(ALL_IMAGES)
+all-image: $(ALL_IMAGES)
 
 fibonacci-python-image:  Dockerfile python/server.py
 	DOCKER_BUILDKIT=1 docker build \

--- a/benchmarks/hotel-app/Makefile
+++ b/benchmarks/hotel-app/Makefile
@@ -31,8 +31,8 @@ ROOT = ../../
 FUNCTIONS = geo profile rate recommendation reservation user search
 ALL_IMAGES = $(addsuffix -image, $(FUNCTIONS))
 
-all: all_image
-all_image: $(ALL_IMAGES)
+all: all-image
+all-image: $(ALL_IMAGES)
 
 
 

--- a/benchmarks/online-shop/Makefile
+++ b/benchmarks/online-shop/Makefile
@@ -4,9 +4,9 @@ ALL_IMAGES = $(addsuffix -image, $(FUNCTIONS))
 
 ROOT = .
 
-all: all_image
+all: all-image
 
-all_image: $(ALL_IMAGES)
+all-image: $(ALL_IMAGES)
 
 adservice-image: ./adservice/Dockerfile
 	DOCKER_BUILDKIT=1 docker build \

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -2,62 +2,69 @@
 
 Most benchmarks can be run locally using docker-compose for testing purposes.
 
-You will need `Docker` and `docker-compose`. Note that a few benchmarks which use Knative Eventing 
+You will need `Docker` and `docker-compose`. Note that a few benchmarks which use Knative Eventing
 can't be without Knative and don't support local execution with docker-compose.
 
 Some benchmarks use XDT, which will require that the `GOPRIVATE_KEY` environment variable is set
 to access the private XDT repository. Some benchmarks will also require access to AWS S3 services
 for file transfer, this requires the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables.
-Contact us if you would like to ask for our keys, or see the [File Transfer](./running_benchmarks.md#file-transfer) 
+Contact us if you would like to ask for our keys, or see the [File Transfer](./running_benchmarks.md#file-transfer)
 section for more information.
 
-1. `cd` to the benchmark's directory, e.g. 
-    [`./benchmarks/chained-function-serving/`](/benchmarks/chained-function-serving/).
-2. Make docker images locally with `make all-image`. 
-    > **Note:**
-    >
-    > Most benchmarks will require the `GOPRIVATE_KEY` environment variable to be built. If you
-    > do not have access to our key yet you can usually skip this step and docker-compose should
-    > pull our pre-built image from docker hub in the next step.
+1. `cd` to the benchmark's directory, e.g.
+   [`./benchmarks/chained-function-serving/`](/benchmarks/chained-function-serving/).
+2. Make docker images locally with `make all-image`.
 
-3. Start the benchmark with docker-compose. Most benchmarks have a number of docker-compose 
-    manifests, only one can be chosen. These are used to enable different features, for example 
-    `docker-compose-s3.yml` or `docker-compose-inline.yml` for choosing between which transfer 
-    type to use.
-    ```bash
-    docker-compose -f <docker-compose manifest filename> up
-    ```
-    > **Note:**
-    >
-    > If s3 is used then the necessary environment variables, `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`
-    > need to be set. see [File Transfer](./running_benchmarks.md#file-transfer) for more details.
-    > If you currently don't have access to s3 then you will only be able to run `-inline` 
-    > manifests
+   > **Note:**
+   >
+   > Most benchmarks will require the `GOPRIVATE_KEY` environment variable to be built. If you
+   > do not have access to our key yet you can usually skip this step and docker-compose should
+   > pull our pre-built image from docker hub in the next step.
+
+3. Start the benchmark with docker-compose. Most benchmarks have a number of docker-compose
+   manifests, only one can be chosen. These are used to enable different features, for example
+   `docker-compose-s3.yml` or `docker-compose-inline.yml` for choosing between which transfer
+   type to use.
+
+   ```bash
+   docker-compose -f <docker-compose manifest filename> up
+   ```
+
+   > **Note:**
+   >
+   > If s3 is used then the necessary environment variables, `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`
+   > need to be set. see [File Transfer](./running_benchmarks.md#file-transfer) for more details.
+   > If you currently don't have access to s3 then you will only be able to run `-inline`
+   > manifests
 
 4. In a new terminal, invoke the interface function with grpcurl. We have included the grpcurl
-    binary in this repository:
-    ```bash
-    ../../tools/bin/grpcurl -plaintext localhost:50051 helloworld.Greeter.SayHello
-    ```
-    Depending on the benchmark, this might take a moment to complete. You can track the logs in
-    the first terminal window to monitor the benchmark progress.
-    > **Note:**
-    > 
-    > All of our docker-compose manifests are configured to expose port 50051, and all interface
-    > functions implement the `helloworld.Greeter.SayHello` rpc service. In rare cases additional
-    > data must be passed to the function using the `-d` flag- this will be stated explicitly
-    > in the README of that particular benchmark.
+   binary in this repository:
+
+   ```bash
+   ../../tools/bin/grpcurl -plaintext localhost:50051 helloworld.Greeter.SayHello
+   ```
+
+   Depending on the benchmark, this might take a moment to complete. You can track the logs in
+   the first terminal window to monitor the benchmark progress.
+
+   > **Note:**
+   >
+   > All of our docker-compose manifests are configured to expose port 50051, and all interface
+   > functions implement the `helloworld.Greeter.SayHello` rpc service. In rare cases additional
+   > data must be passed to the function using the `-d` flag- this will be stated explicitly
+   > in the README of that particular benchmark.
 
 5. (Optionally) You can also invoke the benchmark using the invoker. `golang` will be required to
-    build the invoker binary. Find out more about the invoker [here](/tools/invoker/).
-    ```bash
-    # build the invoker binary
-    cd ../../tools/invoker
-    make invoker
+   build the invoker binary. Find out more about the invoker [here](/tools/invoker/).
 
-    # Specify the hostname through "endpoints.json"
-    echo '[ { "hostname": "localhost" } ]' > endpoints.json
+   ```bash
+   # build the invoker binary
+   cd ../../tools/invoker
+   make invoker
 
-    # Start the invoker with a chosen RPS rate and time
-    ./invoker -port 50051 -dbg -time 60 -rps 0.0667
-    ```
+   # Specify the hostname through "endpoints.json"
+   echo '[ { "hostname": "localhost" } ]' > endpoints.json
+
+   # Start the invoker with a chosen RPS rate and time
+   ./invoker -port 50051 -dbg -time 60 -rps 0.0667
+   ```


### PR DESCRIPTION
`make all-image` is not able to run for all benchmarks because of inconsistencies in the Makefile (e.g. `make all_image`, `make image-all`).
This commit modifies the Makefiles to ensure consistency so that `make all-image` can make docker images locally, as per `running_locally.md`.