### PR TITLE
Migrate from vHive utils to vSwarm ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The standalone functions can therefore be used as microbenchmarks to first pin-p
 - `benchmarks` contains all of the available benchmark source code and manifests.
 - `utils` contains utilities for use within serverless functions, e.g. the tracing module.
 - `tools` is for command-line tools and services useful outside of serverless functions, such as
-   deployment or invokation.
+   deployment or invocation.
 - `runner` is for setting up self-hosted GitHub Actions runners.
 - `docs` contains additional documentation on a number of relevant topics.
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -38,7 +38,7 @@ In gRPC requests, vHive Metadata is passed as field
 vHive metadata is stored in `vhivemetadata` extension attribute of type
 byte array---this is also what TimeseriesDB looks for.
 
-Developers can use `utils/benchmarking/eventing/vhivemetadata` to read
+Developers can use `tools/benchmarking_eventing/vhivemetadata` to read
 and create vHive metadata objects.
 
 ## Benchmarking

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -4,7 +4,7 @@ vHive and how to run the benchmarks.
 
 ## Introduction
 The key points are:
-- The invoker ([examples/invoker](/tools/invoker)) steers load to
+- The invoker ([tools/invoker](/tools/invoker)) steers load to
 a collection of serverless benchmarks (also called _workflows_).
 - Benchmarks can comprise a single or a collection of functions calling
 one another, as well as asynchronous (i.e., eventing) pipelines.
@@ -42,19 +42,19 @@ Developers can use `tools/benchmarking_eventing/vhivemetadata` to read
 and create vHive metadata objects.
 
 ## Benchmarking
-You can use [examples/invoker](/tools/invoker) (the "invoker") to
+You can use [tools/invoker](/tools/invoker) (the "invoker") to
 get the end-to-end latencies of your serving and eventing workflows.
 
 **On any node**, execute the following instructions below **at the root
-of vHive repository** using **bash**:
+of vSwarm repository** using **bash**:
 1. Build the invoker:
     ```bash
-    (cd examples/invoker; go build github.com/ease-lab/vhive/examples/invoker)
+    (cd tools/invoker; go build github.com/ease-lab/vswarm/tools/invoker)
     ```
 
     - Keep the parenthesis so not to change your working directory.
 2. Create your `endpoints.json` file. It is created automatically for
-    you if you use [examples/deployer](/tools/deployer) (the
+    you if you use [tools/deployer](/tools/deployer) (the
     "deployer"), however eventing workflows are not supported by the
     deployer so the following guide is presented; you may use it for
     manually deployed serving workflows too.
@@ -95,7 +95,7 @@ of vHive repository** using **bash**:
     ```
 3. Execute the invoker:
     ```bash
-    ./examples/invoker/invoker
+    ./tools/invoker/invoker
     ```
 
     **Command-line Arguments:**

--- a/tools/benchmarking_eventing/proto/timeseries.proto
+++ b/tools/benchmarking_eventing/proto/timeseries.proto
@@ -25,7 +25,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/ease-lab/vhive/utils/benchmarking/eventing/proto";
+option go_package = "github.com/ease-lab/vSwarm/tools/benchmarking_eventing/proto";
 
 /*
     EXAMPLE USAGE:

--- a/tools/deployer/client.go
+++ b/tools/deployer/client.go
@@ -30,8 +30,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/vhive-serverless/vSwarm/tools/endpoint"
 	log "github.com/sirupsen/logrus"
+	"github.com/vhive-serverless/vSwarm/tools/endpoint"
 )
 
 // Functions is an object for unmarshalled JSON with functions to deploy.
@@ -57,7 +57,7 @@ var (
 
 func main() {
 	funcPath := flag.String("funcPath", "./configs/knative_workloads", "Path to the folder with *.yml files")
-	funcJSONFile := flag.String("jsonFile", "./examples/deployer/functions.json", "Path to the JSON file with functions to deploy")
+	funcJSONFile := flag.String("jsonFile", "./tools/deployer/functions.json", "Path to the JSON file with functions to deploy")
 	endpointsFile := flag.String("endpointsFile", "endpoints.json", "File with endpoints' metadata")
 	deploymentConcurrency := flag.Int("conc", 5, "Number of functions to deploy concurrently (for serving)")
 


### PR DESCRIPTION
Migrate all dependencies in code and documentation from vHive's utils and examples to vSwarm ones in order to retire the former.