### PR TITLE
New workflow to enable automerge for dependbot.

### DIFF
--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Enable automerge on dependabot PRs
+
+on:
+  # See note below about using pull_request_target
+  pull_request_target:
+
+jobs:
+  automerge:
+    name: Enable automerge on dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable automerge on dependabot PRs
+        uses: daneden/enable-automerge-action@v1
+        with:
+          # A personal access token that you have generated and saved in the
+          # repo or org’s encrypted secrets
+          github-token: ${{ secrets.VHIVE_SERVERLESS_ACCESS_KEY }}
+
+          # The name of the PR author to enable automerge for
+          # Defaults to dependabot[bot]
+          allowed-author: "dependabot[bot]"
+
+          # Allowed values: MERGE | SQUASH | REBASE
+          # Defaults to MERGE
+          merge-method: REBASE


### PR DESCRIPTION
This addition enables automerge by default for
dependbot PR's. After approval it will be merged
automatically. This enhances maintainance.

Signed-off-by: David Schall <david.schall@ed.ac.uk>