### PR TITLE
Allow RPS > 1000

### DIFF
--- a/tools/invoker/client.go
+++ b/tools/invoker/client.go
@@ -126,7 +126,11 @@ func runExperiment(endpoints []*endpoint.Endpoint, runDuration int, targetRPS fl
 	Start(TimeseriesDBAddr, endpoints, workflowIDs)
 
 	timeout := time.After(time.Duration(runDuration) * time.Second)
-	tick := time.Tick(time.Duration(1000/targetRPS) * time.Millisecond)
+	d := time.Duration(1000000/targetRPS) * time.Microsecond
+	if d <= 0 {
+		log.Fatalln("Target RPS is too high")
+	}
+	tick := time.Tick(d)
 	start := time.Now()
 loop:
 	for {


### PR DESCRIPTION
If the RPS is higher that 1000 the Invoker will have a delay of 0 which causes to not issue any requests. This patch allows RPS up to 1M and issues a error if the targetRPS it to high